### PR TITLE
feat: emit prefix and context info when parsing

### DIFF
--- a/lib/RdfParser.ts
+++ b/lib/RdfParser.ts
@@ -82,6 +82,8 @@ export class RdfParser<Q extends RDF.BaseQuad = RDF.Quad>  {
       .then((output) => {
         const quads = output.handle.data;
         quads.on('error', (e) => readable.emit('error', e));
+        quads.on('prefix', (prefix, iri) => readable.emit('prefix', prefix, iri));
+        quads.on('context', (ctx) => readable.emit('context', ctx));
         quads.pipe(readable);
       })
       .catch((e) => readable.emit('error', e));


### PR DESCRIPTION
This PR addresses the PR that was opened but not completed:

 * [Added support for context and prefix events](https://github.com/rubensworks/rdf-parse.js/pull/30)

I added additional tests and made sure the linting works.

This allows users to listen to `prefix` and `context` events when using the main `#parse` method that rdf-pars.js provides.