### PR TITLE
chore: don't use node streams

### DIFF
--- a/lib/RdfParser.ts
+++ b/lib/RdfParser.ts
@@ -1,6 +1,6 @@
 import { ActionContext, Actor } from "@comunica/core";
 import * as RDF from "@rdfjs/types";
-import {Readable, PassThrough} from "stream";
+import { Readable, PassThrough } from "readable-stream";
 import { MediatorRdfParseHandle, MediatorRdfParseMediaTypes } from '@comunica/bus-rdf-parse';
 
 /**
@@ -92,7 +92,7 @@ export class RdfParser<Q extends RDF.BaseQuad = RDF.Quad>  {
       })
       .catch((e) => readable.emit('error', e));
 
-    return readable;
+    return readable as unknown as Readable & RDF.Stream;
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "@comunica/mediator-number": "^2.0.1",
     "@comunica/mediator-race": "^2.0.1",
     "@rdfjs/types": "*",
+    "readable-stream": "^4.3.0",
     "stream-to-string": "^1.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3693,7 +3693,7 @@ readable-stream@^2.2.2, readable-stream@~2.3.6:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^4.0.0, readable-stream@^4.2.0:
+readable-stream@^4.0.0, readable-stream@^4.2.0, readable-stream@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.3.0.tgz#0914d0c72db03b316c9733bb3461d64a3cc50cba"
   integrity sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==


### PR DESCRIPTION
Uses readable stream instead of node stream.

Notes:
1. The type conversion is required because of the following typescript compilation error
```
Type 'PassThrough' is not assignable to type 'Stream<Quad> & Readable'.
  Type 'PassThrough' is not assignable to type 'Readable'.
    Types of property 'readableEncoding' are incompatible.
      Type 'string | null' is not assignable to type 'never'.
        Type 'null' 
```

2. Before and after making the changes in this PR, jest emits the following error (running on node 18).
```
Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
```