### PR TITLE
Use `@rdfjs/types` over `rdf-js` in `index.d.ts`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,7 @@
+import type * as RDF from '@rdfjs/types';
 import { RdfParser } from './RdfParser';
+
 export * from "./RdfParser";
+
 // tslint:disable:no-var-requires
-export default <RdfParser> require('../engine-default');
+export default <RdfParser<RDF.Quad>>require('../engine-default');


### PR DESCRIPTION
This should fix the issue of the TS compiler pulling in `rdf-js` to provide `Quad` type for `RdfParser` in `lib/index.d.ts`, which, in turn, was causing projects depending on `rdf-parse` to have to include `rdf-js` as a dependency to make the project compile.

I do not know if this is the best way to do it (assigning a specific type to `RdfParser<Q>`), but this seems to fix the problem without opening the can of worms that is dependency updates.